### PR TITLE
Update 1.mnist_classify.ipynb

### DIFF
--- a/docs/notebook/ch02/1.mnist_classify.ipynb
+++ b/docs/notebook/ch02/1.mnist_classify.ipynb
@@ -511,7 +511,7 @@
     "        transforms.Grayscale(num_output_channels=1),  # Convert to grayscale if needed\n",
     "        transforms.Resize((28, 28)),  # Resize to match MNIST dimensions\n",
     "        transforms.ToTensor(),  # Convert image to tensor\n",
-    "        transforms.Normalize((0.5,), (0.5,))  # Normalize as per model's training\n",
+    "        transforms.Normalize((0.1307,), (0.3081,))  # Normalize as per model's training\n",
     "    ])\n",
     "    image = Image.open(image_path)\n",
     "    image = transform(image).unsqueeze(0)  # Add batch dimension\n",


### PR DESCRIPTION
uniform the Normalization  of the preceding and following text

Set 'Normalize' at the beginning of the code，but it was not unified later on
transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])